### PR TITLE
Adding PlaybackRouteHandler and RegisterRouteHandler 

### DIFF
--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/PlaybackStatusStream.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/PlaybackStatusStream.scala
@@ -1,0 +1,32 @@
+package uba.fi.verysealed.rocola.behavior
+
+import akka.actor.typed.ActorSystem
+import akka.stream.scaladsl.{BroadcastHub, Keep, Source, SourceQueueWithComplete}
+import akka.stream.{Materializer, OverflowStrategy}
+import akka.actor.typed.scaladsl.adapter._
+import uba.fi.verysealed.rocola.behavior.playlist.PlaybackStatusChanged
+
+
+object PlaybackStatusStream {
+  private var queue: Option[SourceQueueWithComplete[PlaybackStatusChanged]] = None
+  private var source: Option[Source[PlaybackStatusChanged, _]] = None
+
+  def initialize()(implicit system: ActorSystem[_]): Unit = {
+    implicit val materializer: Materializer = Materializer(system)
+
+    val (newQueue, newSource) = Source.queue[PlaybackStatusChanged](bufferSize = 100, OverflowStrategy.dropHead)
+      .toMat(BroadcastHub.sink(bufferSize = 256))(Keep.both)
+      .run()
+
+    queue = Some(newQueue)
+    source = Some(newSource)
+  }
+
+  def getSource: Source[PlaybackStatusChanged, _] = {
+    source.getOrElse(throw new IllegalStateException("PlaybackStatusStream not initialized"))
+  }
+
+  def getQueue: SourceQueueWithComplete[PlaybackStatusChanged] = {
+    queue.getOrElse(throw new IllegalStateException("PlaybackStatusStream not initialized"))
+  }
+}

--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/SessionManager.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/SessionManager.scala
@@ -1,0 +1,75 @@
+package uba.fi.verysealed.rocola
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior}
+import spray.json._
+
+object SessionManager {
+  sealed trait Command
+  final case class RegisterDiYei(name: String, ip: String, port: Int, replyTo: ActorRef[RegistrationResponse]) extends Command
+  final case class RegisterListener(name: String, ip: String, port: Int, replyTo: ActorRef[RegistrationResponse]) extends Command
+  final case class ListMembers(replyTo: ActorRef[MembersListResponse]) extends Command
+  final case class RevokeDiYei(replyTo: ActorRef[RevocationResponse]) extends Command
+
+  case class RegistrationResponse(success: Boolean, message: String, token: Option[String] = None)
+  case class MembersListResponse(members: List[Member])
+  case class RevocationResponse(success: Boolean, message: String)
+
+  sealed trait MemberType
+  case object DiYei extends MemberType
+  case object Listener extends MemberType
+
+  case class Member(name: String, ip: String, port: Int, memberType: MemberType)
+
+  object MemberType {
+    implicit val memberTypeFormat: JsonFormat[MemberType] = new JsonFormat[MemberType] {
+      def write(obj: MemberType): JsValue = JsString(obj.toString)
+
+      def read(json: JsValue): MemberType = json match {
+        case JsString("DiYei") => DiYei
+        case JsString("Listener") => Listener
+        case _ => throw new DeserializationException("MemberType expected")
+      }
+    }
+  }
+
+  private var diyei: Option[Member] = None
+  private var listeners: List[Member] = List.empty
+
+  private def generateToken(): String = java.util.UUID.randomUUID().toString
+
+  def apply(): Behavior[Command] = Behaviors.receive { (context, message) =>
+    message match {
+      case RegisterDiYei(name, ip, port, replyTo) =>
+        diyei match {
+          case Some(_) =>
+            replyTo ! RegistrationResponse(success = false, message = "DiYei already registered")
+          case None =>
+            val token = generateToken()
+            diyei = Some(Member(name, ip, port, DiYei))
+            replyTo ! RegistrationResponse(success = true, message = "DiYei registered", token = Some(token))
+        }
+        Behaviors.same
+
+      case RegisterListener(name, ip, port, replyTo) =>
+        listeners = listeners :+ Member(name, ip, port, Listener)
+        replyTo ! RegistrationResponse(success = true, message = "Listener registered")
+        Behaviors.same
+
+      case ListMembers(replyTo) =>
+        val members = diyei.toList ++ listeners
+        replyTo ! MembersListResponse(members)
+        Behaviors.same
+
+      case RevokeDiYei(replyTo) =>
+        diyei match {
+          case Some(_) =>
+            diyei = None
+            replyTo ! RevocationResponse(success = true, message = "DiYei registration revoked")
+          case None =>
+            replyTo ! RevocationResponse(success = false, message = "No DiYei registered")
+        }
+        Behaviors.same
+    }
+  }
+}

--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/behavior/PlayingBehavior.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/behavior/PlayingBehavior.scala
@@ -33,6 +33,12 @@ object SongMetadata {
   implicit val format: RootJsonFormat[SongMetadata] = jsonFormat5(SongMetadata.apply)
 }
 
+object PlayingBehavior {
+  def apply(): Behavior[RocolaCommand] = Behaviors.setup { context =>
+
+    new PlayingBehavior(context)
+  }
+}
 class PlayingBehavior(context: ActorContext[RocolaCommand]
                      ) extends AbstractBehavior[RocolaCommand](context) {
 
@@ -44,7 +50,7 @@ class PlayingBehavior(context: ActorContext[RocolaCommand]
   // Create the classic ActorSystem from the typed ActorSystem
   // Create the Listener actor
   val listener: ActorRef[SongPlaybackEvent] = context.spawn(Listener(), "listener")
-  val songsPlayer = new SongPlayer(context, listener)
+  val songsPlayer = new SongPlayer(context, listener, PlaybackStatusStream.getQueue)
 
   // Method to search for a song by title and artist
   def searchSong(title: String, artist: String): Option[SongMetadata] = {

--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/PlaybackRouteHandler.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/PlaybackRouteHandler.scala
@@ -1,0 +1,154 @@
+package uba.fi.verysealed.rocola.routes
+
+import akka.actor.typed.scaladsl.AskPattern.Askable
+import akka.actor.typed.{ActorRef, ActorSystem}
+import akka.http.scaladsl.marshalling.sse.EventStreamMarshalling._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.scaladsl.Source
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+import uba.fi.verysealed.rocola.RocolaManager._
+import uba.fi.verysealed.rocola.behavior.playlist.PlaybackStatusChanged
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+// Define the JSON response case class
+case class PlaybackResponseMessage(message: String, success: Boolean)
+
+// Define the JSON format for the response
+object PlaybackResponseMessage {
+  implicit val format: RootJsonFormat[PlaybackResponseMessage] = jsonFormat2(PlaybackResponseMessage.apply)
+}
+
+object PlaybackRouteHandler {
+  def apply(source: Source[PlaybackStatusChanged, _], rocolaManager: ActorRef[RocolaCommand])(implicit system: ActorSystem[_]): Route = {
+    implicit val timeout: akka.util.Timeout = 5.seconds
+
+    path("playback-status") {
+      get {
+        complete {
+          source
+            .map { status =>
+              ServerSentEvent(status.message)
+            }
+            .keepAlive(10.second, () => ServerSentEvent.heartbeat)
+        }
+      }
+    } ~
+      path("play") {
+        get {
+          val responseFuture: Future[PlaybackResponse] = rocolaManager.ask(ref => SendPlay(ref))(timeout, system.scheduler)
+          onSuccess(responseFuture) { response =>
+            if (response.success) {
+              complete(PlaybackResponseMessage(s"Play started", success = true))
+            } else {
+              complete(PlaybackResponseMessage(s"Failed to start playing", success = false))
+            }
+          }
+
+        }
+      } ~
+      path("pause") {
+        get {
+          val responseFuture: Future[PlaybackResponse] = rocolaManager.ask(ref => SendPause(ref))(timeout, system.scheduler)
+          onSuccess(responseFuture) { response =>
+            if (response.success) {
+              complete(PlaybackResponseMessage(s"Play paused", success = true))
+            } else {
+              complete(PlaybackResponseMessage(s"Failed to pause playing", success = false))
+            }
+
+          }
+        }
+      } ~
+      path("stop") {
+        get {
+          val responseFuture: Future[PlaybackResponse] = rocolaManager.ask(ref => SendStop(ref))(timeout, system.scheduler)
+          onSuccess(responseFuture) { response =>
+            if (response.success) {
+              complete(PlaybackResponseMessage(s"Play stopped", success = true))
+            } else {
+              complete(PlaybackResponseMessage(s"Failed to stop playing", success = false))
+            }
+          }
+        } ~
+          path("skip") {
+            get {
+              val responseFuture: Future[PlaybackResponse] = rocolaManager.ask(ref => SendSkipSong(ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"Song skipped", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to skip song", success = false))
+                }
+              }
+            }
+          } ~
+          path("volume-up") {
+            get {
+              val responseFuture: Future[VolumeControlResponse] = rocolaManager.ask(ref => SendVolumeUp(ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"volume increased", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to increase volume", success = false))
+                }
+              }
+            }
+          } ~
+          path("volume-down") {
+            get {
+              val responseFuture: Future[VolumeControlResponse] = rocolaManager.ask(ref => SendVolumeDown(ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"Volume decreased", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to decrease volume", success = false))
+                }
+              }
+            }
+          } ~
+          path("mute") {
+            get {
+              val responseFuture: Future[VolumeControlResponse] = rocolaManager.ask(ref => SendMute(ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"Volume muted", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to mute volume", success = false))
+                }
+              }
+            }
+          } ~
+          path("unmute") {
+            get {
+              val responseFuture: Future[VolumeControlResponse] = rocolaManager.ask(ref => SendUnmute(ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"Volume unmuted", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to unmute volume", success = false))
+                }
+              }
+            }
+          } ~
+          path("set-volume" / IntNumber) { volume =>
+            get {
+              val responseFuture: Future[VolumeControlResponse] = rocolaManager.ask(ref => SetVolume(volume, ref))(timeout, system.scheduler)
+              onSuccess(responseFuture) { response =>
+                if (response.success) {
+                  complete(PlaybackResponseMessage(s"Volume set", success = true))
+                } else {
+                  complete(PlaybackResponseMessage(s"Failed to set volume", success = false))
+                }
+              }
+            }
+          }
+      }
+  }
+}
+

--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/PlaylistRouteHandler.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/PlaylistRouteHandler.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
 import spray.json.DefaultJsonProtocol._
-import spray.json.{RootJsonFormat, JsValue, DeserializationException}
+import spray.json.RootJsonFormat
 import uba.fi.verysealed.rocola.RocolaManager
 import uba.fi.verysealed.rocola.behavior.SongMetadata
 
@@ -89,6 +89,6 @@ class PlaylistRouteHandler(rocolaManager: ActorRef[RocolaManager.RocolaCommand],
           }
         }
       }
-  }
+}
 
 

--- a/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/RegisterRouteHandler.scala
+++ b/main-sbt/src/main/scala/uba/fi/verysealed/rocola/routes/RegisterRouteHandler.scala
@@ -1,0 +1,93 @@
+package uba.fi.verysealed.rocola.routes
+
+import akka.actor.typed.{ActorRef, ActorSystem}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.util.Timeout
+import spray.json.DefaultJsonProtocol.jsonFormat3
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat, RootJsonFormat}
+import uba.fi.verysealed.rocola.SessionManager
+import uba.fi.verysealed.rocola.SessionManager._
+import uba.fi.verysealed.rocola.behavior.SongMetadata
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object RegisterRouteHandler extends DefaultJsonProtocol {
+  // Custom JSON format for MemberType
+  implicit object MemberTypeFormat extends JsonFormat[MemberType] {
+    def write(memberType: MemberType): JsValue = memberType match {
+      case DiYei   => JsString("DiYei")
+      case Listener => JsString("Listener")
+    }
+    def read(value: JsValue): MemberType = value match {
+      case JsString("DiYei")   => DiYei
+      case JsString("Listener") => Listener
+      case _ => throw new DeserializationException("MemberType expected")
+    }
+  }
+
+
+  implicit val memberFormat: RootJsonFormat[Member] = jsonFormat4(Member)
+  implicit val membersListResponseFormat: RootJsonFormat[MembersListResponse] = jsonFormat1(MembersListResponse)
+  implicit val revocationResponseFormat: RootJsonFormat[RevocationResponse] = jsonFormat2(RevocationResponse)
+
+  // Define the JSON response case class
+  case class RegistrationResponseMessage(message: String, success: Boolean, token: String)
+
+  // Define the JSON format for the response
+  object RegistrationResponseMessage {
+    implicit val format: RootJsonFormat[RegistrationResponseMessage] = jsonFormat3(RegistrationResponseMessage.apply)
+  }
+
+  case class RegisterRequest(name: String, ip: String, port: Int)
+  implicit val registerRequestFormat: RootJsonFormat[RegisterRequest] = jsonFormat3(RegisterRequest)
+
+
+  def apply(sessionManager: ActorRef[SessionManager.Command])(implicit system: ActorSystem[_]): Route = {
+    implicit val timeout: Timeout = 5.seconds
+
+    path("register-diyei") {
+      post {
+        entity(as[RegisterRequest]) { request =>
+          val responseFuture: Future[RegistrationResponse] = sessionManager.ask(ref => RegisterDiYei(request.name, request.ip, request.port, ref))
+          onSuccess(responseFuture) { response =>
+            if (response.success){
+              complete(RegistrationResponseMessage(response.message, response.success,response.token.get ))
+            }
+            else
+              {
+                complete(RegistrationResponseMessage(response.message, response.success,"" ))
+              }
+          }
+        }
+      }
+    } ~
+      path("register-listener") {
+        post {
+          entity(as[RegisterRequest]) { request =>
+            val responseFuture: Future[RegistrationResponse] = sessionManager.ask(ref => RegisterListener(request.name, request.ip, request.port, ref))
+            onSuccess(responseFuture) { response =>
+              if (response.success){
+                complete(RegistrationResponseMessage(response.message, response.success,"" ))
+              }
+              else
+              {
+                complete(RegistrationResponseMessage(response.message, response.success,"" ))
+              }
+            }
+          }
+        }
+      } ~
+      path("list-members") {
+        get {
+          val responseFuture: Future[MembersListResponse] = sessionManager.ask(ref => ListMembers(ref))
+          onSuccess(responseFuture) { response =>
+            complete(response)
+          }
+        }
+      }
+  }
+}


### PR DESCRIPTION
Adding PlaybackRouteHandler to manage playback events from api rest to RocolaManager

Adding RegisterRouteHandler to manage registration in Directory, allowing to register a Diyei and receive a token, register unlimited number of listeners and finally, listing them all. Token is not used by now, but could be included to complete directory to only accept playback and playlist methods when token is available. Pending to include revoke mechanism to allow others to be Diyei